### PR TITLE
chore: configure prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+end_of_line = lf
+max_line_length = 80

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+singleQuote: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
     "name": "n8n",
     "main": "src/index.ts",
+    "scripts": {
+        "format": "prettier -w ."
+    },
     "dependencies": {
         "@pulumi/aws": "^6.67.0",
         "@pulumi/awsx": "^2.21.0",


### PR DESCRIPTION
Split the prettier config between the combo of `.editorconfig` and `.prettierrc` files.
Add script for code formatting and ignore `pnpm-lock.yaml` when formatting.