### PR TITLE
docs: instruct to use parameter hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo ./aws/install
 
 - Set up AWS CLI, see https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 - Set up n8n environment using AWS Parameter Store on the target AWS Account by:
-  - Defining plain parameters:
+  - Defining plain parameters using hierarchy and configuring `n8n:envPath` on the stack level:
     - `N8N_LOG_LEVEL` - one of `debug`, `info`, `warn`, `error`
     - `N8N_SMTP_HOST` - SMTP server name
     - `N8N_SMTP_PORT` - use STARTTLS port, e.g. 587, since SSL for SMTP is disabled
@@ -56,7 +56,7 @@ sudo ./aws/install
     - `N8N_SMTP_SENDER` - sender email address, e.g. info@dev.n8n.gostudion.com
     - `N8N_EDITOR_BASE_URL` - URL to access the instance, e.g. https://dev.n8n.gostudion.com/
     - `WEBHOOK_URL` - URL for webhooks with external services, e.g. https://dev.n8n.gostudion.com/
-  - Defining secret parameter:
+  - Defining secret parameter using hierarchy and configuring `n8n:secretsPath` on the stack level:
     - `N8N_SMTP_PASS` - SMTP password
 - Create a new stack for a custom use case
 


### PR DESCRIPTION
Using parameter hierarchy is encouraged when defining parameters on the AWS Parameter Store, and consequently defining the `n8n:envPath` and `n8n:secretsPath` on the stack level to pull the parameters.