### PR TITLE
chore: move hosted zone on the stack level

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -1,5 +1,6 @@
 config:
   aws:region: us-east-1
+  n8n:hostedZoneId: Z02311331OB53ZPGY9YFJ
   n8n:domain: dev.n8n.gostudion.com
   n8n:pgVersion: 17.2
   n8n:dockerImage: n8nio/n8n:1.89.1

--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -9,4 +9,3 @@ config:
     value:
       pulumi:template: aws-typescript
   n8n:port: 5678
-  n8n:hostedZoneId: Z02311331OB53ZPGY9YFJ


### PR DESCRIPTION
The hosted zone ID configuration option is now moved to the stack level to support use of multiple AWS accounts and DNS delegation.