### PR TITLE
chore: update `dev` n8n to `v1.99.0`

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -3,7 +3,7 @@ config:
   n8n:hostedZoneId: Z02311331OB53ZPGY9YFJ
   n8n:domain: dev.n8n.gostudion.com
   n8n:pgVersion: 17.2
-  n8n:dockerImage: n8nio/n8n:1.89.1
+  n8n:dockerImage: n8nio/n8n:1.99.0
   n8n:serverSize: small
   n8n:serverCount: 1
   n8n:envPath: /n8n/dev/env/


### PR DESCRIPTION
The `dev` stack n8n is updated to `v1.99.0`